### PR TITLE
feat(jira): added environment mapping

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,38 @@
+HELP.md
+.gradle
+build/
+!gradle/wrapper/gradle-wrapper.jar
+!**/src/main/**/build/
+!**/src/test/**/build/
+
+### STS ###
+.apt_generated
+.classpath
+.factorypath
+.project
+.settings
+.springBeans
+.sts4-cache
+bin/
+!**/src/main/**/bin/
+!**/src/test/**/bin/
+
+### IntelliJ IDEA ###
+.DS_Store
+.idea
+*.iws
+*.iml
+*.ipr
+out/
+!**/src/main/**/out/
+!**/src/test/**/out/
+
+### NetBeans ###
+/nbproject/private/
+/nbbuild/
+/dist/
+/nbdist/
+/.nb-gradle/
+
+### VS Code ###
+.vscode/

--- a/.jira/README.md
+++ b/.jira/README.md
@@ -1,0 +1,14 @@
+# 🌍 Jira Environment Mapping for Deployments
+
+_see
+also: [Environment Mapping Docs](https://github.com/atlassian/github-for-jira/blob/main/docs/deployments.md#environment-mapping)_
+
+This repo uses `.jira/config.yml` to map deployment environments in Jira tickets, making sure Jira recognizes the
+correct environment type.
+
+## 🚀 How it works:
+
+1️⃣ **Jira listens** to GitHub deployment events and checks the `environment name`.  
+2️⃣ **Jira reads** the issue keys from commit messages (e.g., `JIRA-123`).  
+3️⃣ **Jira maps** the environment name to a type (e.g., `development`, `testing`, `staging`, `production`) based on
+`.jira/config.yml` in the `main` branch. and updates the ticket.

--- a/.jira/config.yml
+++ b/.jira/config.yml
@@ -1,0 +1,20 @@
+deployments:
+  environmentMapping:
+    development:
+      - "dev"
+      - "dev-*"
+      - "development"
+      - "development-*"
+    testing:
+      - "test"
+      - "test-*"
+      - "testing"
+      - "testing-*"
+    staging:
+      - "mtp"
+      - "mtp-*"
+    production:
+      - "ps"
+      - "ps-*"
+      - "prod"
+      - "prod-*"


### PR DESCRIPTION
# 🌍 Jira Environment Mapping for Deployments

_see
also: [Environment Mapping Docs](https://github.com/atlassian/github-for-jira/blob/main/docs/deployments.md#environment-mapping)_

This repo uses `.jira/config.yml` to map deployment environments in Jira tickets, making sure Jira recognizes the
correct environment type.

## 🚀 How it works:

1️⃣ **Jira listens** to GitHub deployment events and checks the `environment name`.  
2️⃣ **Jira reads** the issue keys from commit messages (e.g., `JIRA-123`).  
3️⃣ **Jira maps** the environment name to a type (e.g., `development`, `testing`, `staging`, `production`) based on
`.jira/config.yml` in the `main` branch. and updates the ticket.
